### PR TITLE
removing forbidden characters from asset names for PDF and SVG

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -232,7 +232,9 @@ const App = () => {
                     blob = await arrayBufferToWebP(exportData.buffer, { quality: 100 });
                   }
 
-                  zip.file(`${exportData.name}.${exportData.format}`, blob)
+                  const exportName = exportData.name.replace(/ /gi, "_").replace(/-/gi, "_").replace(/=/gi, "_").replace(/,/gi, "_").replace(/\//gi, "_");
+
+                  zip.file(`${exportName}.${exportData.format}`, blob)
                 })
               )
 
@@ -246,7 +248,9 @@ const App = () => {
                 blob = await arrayBufferToWebP(exportData.buffer, { quality: 100 })
               }
 
-              saveAs(blob, `${exportData.name}.${exportData.format}`)
+              const exportName = exportData.name.replace(/ /gi, "_").replace(/-/gi, "_").replace(/=/gi, "_").replace(/,/gi, "_").replace(/\//gi, "_");
+
+              saveAs(blob, `${exportName}.${exportData.format}`)
 
               parent.postMessage({
                 pluginMessage: {


### PR DESCRIPTION
If figma project has "Variant" feature, figma generate assets names with some forbidden characters for both Android and iOS such as "=", "/", ",". In this changes, I have replaced these forbidden characters with "_". To get more details about the problem, please see the figma forum page
https://forum.figma.com/t/control-variant-export-naming-especially-for-icons/1605

more details about figma variants: https://help.figma.com/hc/en-us/articles/360056440594-Create-and-use-variants

Note: We have already fixed the problem for android & iOS assets, however PDF and SVG are suffering the same issue. This commit will fix them